### PR TITLE
Improve plugin structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# WPSoluces Core (MU-Plugin)
+# WPSoluces Core (Plugin)
 ## Installation
 
-1. **Copiez** le dossier `wpsoluces-core/` entier ainsi que `wpsoluces-core.php` dans :
+1. **Copiez** le dossier `wpsoluces-core/` dans :
 ```
 
-wp-content/mu-plugins/
+wp-content/plugins/
 
 ```
-2. Vérifiez que le fichier principal `mu-plugins/wpsoluces-core.php` est bien chargé automatiquement par WordPress (les MU-Plugins sont activés par défaut).
+2. Activez « WPSoluces Core » depuis l'administration WordPress.
 
 ---
 
@@ -26,15 +26,6 @@ Chaque module est démarré automatiquement par `Core\Init::run()` :
 | **DisableXmlRpc**            | Désactive complètement XML-RPC, les pingbacks/RSD/WLW, et bloque toute requête directe vers `xmlrpc.php`.         |
 
 ---
-
-## Pourquoi MU-Plugin ?
-
-- **Chargement automatique** : pas besoin d’activer manuellement.
-- **Sécurité renforcée** : modules critiques toujours en place.
-- **Centralisation** : tous vos réglages “core” dans un seul dossier.
-
----
-
 ## Support et contributions
 
 Pour toute suggestion ou bug, ouvrez une issue sur le dépôt Git ou contactez Guillaume de WPSoluces.

--- a/wpsoluces-core/wpsoluces-core.php
+++ b/wpsoluces-core/wpsoluces-core.php
@@ -18,11 +18,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 /* ------------------------------------------------------------------------- */
 /* Chemins utiles                                                            */
 /* ------------------------------------------------------------------------- */
-define( 'WPSC_PATH', __DIR__ . '/wpsoluces-core' );
-define( 'WPSC_URL',  plugin_dir_url( __FILE__ ) . 'wpsoluces-core' );
+define( 'WPSC_PATH', __DIR__ );
+define( 'WPSC_URL',  plugin_dir_url( __FILE__ ) );
 
 /* ------------------------------------------------------------------------- */
 /* Amorçage                                                                  */
 /* ------------------------------------------------------------------------- */
 require_once WPSC_PATH . '/Core/Init.php';
-\WPSolucesCore\Core\Init::run();
+
+/**
+ * Initialise tous les modules une fois les plugins chargés.
+ */
+function wpsc_core_boot(): void {
+    \WPSolucesCore\Core\Init::run();
+}
+add_action( 'plugins_loaded', 'wpsc_core_boot' );
+
+/**
+ * Activation du plugin : enregistre les règles de réécriture.
+ */
+function wpsc_core_activate(): void {
+    wpsc_core_boot();
+    flush_rewrite_rules( false );
+}
+register_activation_hook( __FILE__, 'wpsc_core_activate' );
+
+/**
+ * Désactivation du plugin : purge les réécritures.
+ */
+function wpsc_core_deactivate(): void {
+    flush_rewrite_rules( false );
+}
+register_deactivation_hook( __FILE__, 'wpsc_core_deactivate' );


### PR DESCRIPTION
## Summary
- remove strict_types declarations from the plugin
- move main plugin file inside the plugin folder
- update constants to match new location
- simplify install instructions in README

## Testing
- `find . -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_685d1b24562c83238faae2180dffa512