### PR TITLE
Fix login redirect logout when slug first set

### DIFF
--- a/wpsoluces-core/Modules/LoginRedirect/Controller.php
+++ b/wpsoluces-core/Modules/LoginRedirect/Controller.php
@@ -30,7 +30,17 @@ class Controller {
                         20, 2
                 );
                 add_action(
+                        'add_option_' . Model::OPTION_ACTIVE,
+                        [ self::class, 'flush_and_logout' ],
+                        20, 2
+                );
+                add_action(
                         'update_option_' . Model::OPTION_SLUG,
+                        [ self::class, 'flush_and_logout' ],
+                        20, 2
+                );
+                add_action(
+                        'add_option_' . Model::OPTION_SLUG,
                         [ self::class, 'flush_and_logout' ],
                         20, 2
                 );


### PR DESCRIPTION
## Summary
- ensure LoginRedirect flushes rewrite rules and logs out when options are created

## Testing
- `php -l wpsoluces-core/Modules/LoginRedirect/Controller.php`


------
https://chatgpt.com/codex/tasks/task_e_685d66a03c148323b95969eb0a3bf175