### PR TITLE
Fix flush_and_logout when option unchanged

### DIFF
--- a/wpsoluces-core/Modules/LoginRedirect/Controller.php
+++ b/wpsoluces-core/Modules/LoginRedirect/Controller.php
@@ -243,6 +243,10 @@ class Controller {
 	 * Flush + logout lors activation/désactivation
 	 * ------------------------------------------------------------------ */
        public static function flush_and_logout( $old, $new ): void {
+               if ( $old === $new ) {
+                       return;
+               }
+
                flush_rewrite_rules( false );
                delete_option( Model::OPTION_FLUSHED );
 


### PR DESCRIPTION
## Summary
- avoid flushing and logout in LoginRedirect when an option value hasn't changed

## Testing
- `php -l wpsoluces-core/Modules/LoginRedirect/Controller.php`


------
https://chatgpt.com/codex/tasks/task_e_685d69a66f0c8323aa4e9f5fbacea7fe