### PR TITLE
Use constant for login slug

### DIFF
--- a/wpsoluces-core/Modules/LoginRedirect/Controller.php
+++ b/wpsoluces-core/Modules/LoginRedirect/Controller.php
@@ -81,12 +81,12 @@ class Controller {
                 register_setting(
                         'wpsc_lr_group',
                         Model::OPTION_SLUG,
-                        [
+                       [
                                 'type'              => 'string',
                                 'sanitize_callback' => 'sanitize_title',
-                                'default'           => 'connect',
+                                'default'           => Model::DEFAULT_SLUG,
                         ]
-                );
+               );
 
 
                 add_settings_section(

--- a/wpsoluces-core/Modules/LoginRedirect/Model.php
+++ b/wpsoluces-core/Modules/LoginRedirect/Model.php
@@ -4,6 +4,7 @@ namespace WPSolucesCore\Modules\LoginRedirect;
 defined( 'ABSPATH' ) || exit;
 
 class Model {
+       public const DEFAULT_SLUG = 'connect';
         public const OPTION_ACTIVE  = 'wpsc_lr_active';
         public const OPTION_SLUG    = 'wpsc_lr_slug';
         public const OPTION_FLUSHED = 'wpsc_lr_rewrite_flushed';
@@ -12,9 +13,9 @@ class Model {
                 return (bool) get_option( self::OPTION_ACTIVE, 0 );
         }
 
-        public static function slug(): string {
-                $slug = trim( (string) get_option( self::OPTION_SLUG, 'connect' ) );
-                return $slug !== '' ? $slug : 'connect';
-        }
+       public static function slug(): string {
+               $slug = trim( (string) get_option( self::OPTION_SLUG, self::DEFAULT_SLUG ) );
+               return $slug !== '' ? $slug : self::DEFAULT_SLUG;
+       }
 
 }

--- a/wpsoluces-core/Modules/LoginRedirect/View.php
+++ b/wpsoluces-core/Modules/LoginRedirect/View.php
@@ -59,6 +59,6 @@ class View {
      */
     public static function slug_field(): void {
         echo '<span class="wpsc-url-prefix">' . esc_url( home_url( '/' ) ) . '</span>';
-        echo '<input type="text" name="' . esc_attr( Model::OPTION_SLUG ) . '" value="' . esc_attr( Model::slug() ) . '" class="regular-text" placeholder="connect" />';
+        echo '<input type="text" name="' . esc_attr( Model::OPTION_SLUG ) . '" value="' . esc_attr( Model::slug() ) . '" class="regular-text" placeholder="' . esc_attr( Model::DEFAULT_SLUG ) . '" />';
     }
 }


### PR DESCRIPTION
## Summary
- define `Model::DEFAULT_SLUG`
- use that constant everywhere instead of a hard-coded string

## Testing
- `php -l wpsoluces-core/Modules/LoginRedirect/Model.php`
- `php -l wpsoluces-core/Modules/LoginRedirect/Controller.php`
- `php -l wpsoluces-core/Modules/LoginRedirect/View.php`


------
https://chatgpt.com/codex/tasks/task_e_685d69a6ffe8832388fd0047a3a86234