### PR TITLE
Remove admin UI from LoginLimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Chaque module est démarré automatiquement par `Core\Init::run()` :
 | **TagManager**               | Intègre Google Tag Manager sur chaque page, avec filtrage possible des réglages.   -> menu Réglages |
 | **LoginRedirect**            | Redirige tout accès à `/wp-admin` ou `/wp-login.php` vers une URL de connexion personnalisable.   -> menu Réglages |
 | **DuplicatePost**            | Active la duplication d’articles et de pages directement depuis le tableau de bord par défaut.                              |
-| **LoginLimiter**             | Verrouille les tentatives de connexion (nombre et durée configurables), même pour des comptes inexistants.             |
+| **LoginLimiter**             | Verrouille les tentatives de connexion après 5 échecs pendant 30&nbsp;minutes, même pour des comptes inexistants. |
 | **HideVersion**              | Cache la version de WordPress (meta generator, paramètres `?ver` sur les assets), pour réduire la surface d’attaque. |
 | **DisableXmlRpc**            | Désactive complètement XML-RPC, les pingbacks/RSD/WLW, et bloque toute requête directe vers `xmlrpc.php`.         |
 

--- a/wpsoluces-core/Modules/LoginLimiter/Controller.php
+++ b/wpsoluces-core/Modules/LoginLimiter/Controller.php
@@ -4,7 +4,7 @@ namespace WPSolucesCore\Modules\LoginLimiter;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LoginLimiter – limite les connexions en fonction du login et de l’IP.
+ * LoginLimiter – limite les connexions en fonction du login.
  * • Compte toute erreur (mauvais login OU mauvais mot de passe).
  * • Incrémente → vérifie → bloque dans le même hook « authenticate » (prio 100).
  */
@@ -12,13 +12,8 @@ class Controller {
 
     /** Secondes restantes pour l’erreur courante. */
     private static int $remain = 0;
-    private static ?string $page_hook = null;
 
     public static function register(): void {
-
-        /* ADMIN */
-        add_action( 'admin_menu', [ self::class, 'add_settings_page' ] );
-        add_action( 'admin_init', [ self::class, 'register_settings' ] );
 
         /* UN SEUL filtre « authenticate » à prio 100  ➜  fin du pipeline WP */
         add_filter( 'authenticate', [ self::class, 'check_and_count' ], 100, 3 );
@@ -32,77 +27,6 @@ class Controller {
         add_filter( 'login_errors', [ self::class, 'replace_error' ] );
     }
 
-    /* ---------------------------------------------------------------------
-     * ADMIN
-     * ------------------------------------------------------------------ */
-    public static function add_settings_page(): void {
-        self::$page_hook = add_options_page(
-            __( 'Blocage connexion', 'wpsoluces' ),
-            'Blocage connexion',
-            'manage_options',
-            'wpsc-ll',
-            [ self::class, 'render_settings_page' ]
-        );
-    }
-
-    public static function register_settings(): void {
-        register_setting( 'wpsc_ll_group', Model::OPTION_MAX_ATTEMPTS, [ 'type' => 'integer', 'default' => 5 ] );
-        register_setting( 'wpsc_ll_group', Model::OPTION_LOCK_MINUTES, [ 'type' => 'integer', 'default' => 30 ] );
-
-        add_settings_section(
-            'wpsc_ll_section',
-            __( 'Limitation des tentatives', 'wpsoluces' ),
-            null,
-            'wpsc-ll'
-        );
-
-        add_settings_field(
-            'wpsc_ll_max',
-            __( 'Nombre maximal d\'essais', 'wpsoluces' ),
-            [ self::class, 'field_max_attempts' ],
-            'wpsc-ll',
-            'wpsc_ll_section'
-        );
-
-        add_settings_field(
-            'wpsc_ll_lock',
-            __( 'Durée de blocage (min)', 'wpsoluces' ),
-            [ self::class, 'field_lock_minutes' ],
-            'wpsc-ll',
-            'wpsc_ll_section'
-        );
-    }
-
-    public static function render_settings_page(): void {
-        ?>
-        <div class="wrap">
-            <h1><?php esc_html_e( 'Blocage connexion', 'wpsoluces' ); ?></h1>
-            <form method="post" action="options.php">
-                <?php
-                settings_fields( 'wpsc_ll_group' );
-                do_settings_sections( 'wpsc-ll' );
-                submit_button();
-                ?>
-            </form>
-        </div>
-        <?php
-    }
-
-    public static function field_max_attempts(): void {
-        printf(
-            '<input type="number" name="%1$s" value="%2$d" class="small-text" min="1" />',
-            esc_attr( Model::OPTION_MAX_ATTEMPTS ),
-            Model::max_attempts()
-        );
-    }
-
-    public static function field_lock_minutes(): void {
-        printf(
-            '<input type="number" name="%1$s" value="%2$d" class="small-text" min="1" />',
-            esc_attr( Model::OPTION_LOCK_MINUTES ),
-            Model::lock_minutes()
-        );
-    }
 
     /**
      * Incrémente le compteur si échec, puis bloque si seuil atteint.

--- a/wpsoluces-core/Modules/LoginLimiter/Model.php
+++ b/wpsoluces-core/Modules/LoginLimiter/Model.php
@@ -5,13 +5,16 @@ defined( 'ABSPATH' ) || exit;
 
 class Model {
 
-    public const OPTION_MAX_ATTEMPTS = 'wpsc_ll_max';
-    public const OPTION_LOCK_MINUTES = 'wpsc_ll_lock';
+    /** Nombre maximal d'essais. */
+    private const MAX_ATTEMPTS = 5;
+
+    /** Durée de blocage en minutes. */
+    private const LOCK_MINUTES = 30;
+
     private const PREFIX = 'wpsc_ll_';
 
     private static function key( string $login ): string {
-        $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
-        return self::PREFIX . md5( strtolower( $login ) . '|' . $ip );
+        return self::PREFIX . md5( strtolower( $login ) );
     }
 
     public static function get_attempts( string $login ): int {
@@ -19,11 +22,11 @@ class Model {
     }
 
     public static function max_attempts(): int {
-        return (int) get_option( self::OPTION_MAX_ATTEMPTS, 5 );
+        return self::MAX_ATTEMPTS;
     }
 
     public static function lock_minutes(): int {
-        return (int) get_option( self::OPTION_LOCK_MINUTES, 30 );
+        return self::LOCK_MINUTES;
     }
 
     public static function increment( string $login ): void {


### PR DESCRIPTION
## Summary
- remove LoginLimiter settings page and options
- drop IP filtering for lockouts
- simplify LoginLimiter configuration constants
- update README to reflect fixed behaviour

## Testing
- `find wpsoluces-core -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_685d6caa27ac832384eb77a624ec44fe