### PR TITLE
Remove settings section description

### DIFF
--- a/wpsoluces-core/Modules/LoginRedirect/Controller.php
+++ b/wpsoluces-core/Modules/LoginRedirect/Controller.php
@@ -92,7 +92,7 @@ class Controller {
                add_settings_section(
                        'wpsc_lr_section',
                        __( 'Déplacement de la page de connexion', 'wpsoluces' ),
-                       [ View::class, 'section_description' ],
+                       '__return_null',
                        'wpsc-lr'
                );
 

--- a/wpsoluces-core/Modules/LoginRedirect/View.php
+++ b/wpsoluces-core/Modules/LoginRedirect/View.php
@@ -23,16 +23,6 @@ class View {
         );
     }
 
-    /**
-     * Description de la section réglages.
-     */
-    public static function section_description(): void {
-        printf(
-            '<p>%s %s</p>',
-            self::get_notice_message(),
-            esc_html__( 'Nouvelle URL personnalisable ci-dessous.', 'wpsoluces' )
-        );
-    }
 
     /**
      * Page complète


### PR DESCRIPTION
## Summary
- show only the section heading on the Login Redirect settings page

## Testing
- `php -l wpsoluces-core/Modules/LoginRedirect/Controller.php`
- `php -l wpsoluces-core/Modules/LoginRedirect/View.php`


------
https://chatgpt.com/codex/tasks/task_e_685d812ef3d48323b07e1ff793a04a5c