### PR TITLE
Implement centralized uninstall class

### DIFF
--- a/wpsoluces-core/Core/Uninstall.php
+++ b/wpsoluces-core/Core/Uninstall.php
@@ -1,0 +1,60 @@
+<?php
+namespace WPSolucesCore\Core;
+
+use WPSolucesCore\Modules\TagManager\Model as TagManager;
+use WPSolucesCore\Modules\LoginLimiter\Model as LoginLimiter;
+use WPSolucesCore\Modules\LoginRedirect\Model as LoginRedirect;
+
+/**
+ * Centralise la désinstallation du plugin.
+ */
+class Uninstall {
+    public static function run(): void {
+        global $wpdb;
+
+        // Options enregistrées par les modules
+        $options = [
+            LoginRedirect::OPTION_ACTIVE,
+            LoginRedirect::OPTION_SLUG,
+            LoginRedirect::OPTION_FLUSHED,
+            TagManager::OPTION_KEY_ID,
+            TagManager::OPTION_KEY_ACTIVE,
+        ];
+
+        foreach ( $options as $option ) {
+            delete_option( $option );
+            delete_site_option( $option );
+        }
+
+        // Transient du Tag Manager
+        delete_transient( TagManager::TRANSIENT_KEY );
+        delete_site_transient( TagManager::TRANSIENT_KEY );
+
+        // Tous les transients du LoginLimiter
+        if ( $wpdb instanceof \wpdb ) {
+            $prefix = 'wpsc_ll_';
+            $like   = $wpdb->esc_like( $prefix );
+            $names  = $wpdb->get_col( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE '_transient_{$like}%' OR option_name LIKE '_transient_timeout_{$like}%'" );
+            foreach ( $names as $name ) {
+                if ( str_starts_with( $name, '_transient_timeout_' ) ) {
+                    delete_option( $name );
+                } elseif ( str_starts_with( $name, '_transient_' ) ) {
+                    $transient = substr( $name, 11 ); // _transient_
+                    delete_transient( $transient );
+                }
+            }
+
+            if ( is_multisite() ) {
+                $site_names = $wpdb->get_col( "SELECT meta_key FROM {$wpdb->sitemeta} WHERE meta_key LIKE '_site_transient_{$like}%' OR meta_key LIKE '_site_transient_timeout_{$like}%'" );
+                foreach ( $site_names as $name ) {
+                    if ( str_starts_with( $name, '_site_transient_timeout_' ) ) {
+                        delete_site_option( $name );
+                    } elseif ( str_starts_with( $name, '_site_transient_' ) ) {
+                        $transient = substr( $name, 16 ); // _site_transient_
+                        delete_site_transient( $transient );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/wpsoluces-core/wpsoluces-core.php
+++ b/wpsoluces-core/wpsoluces-core.php
@@ -39,6 +39,7 @@ define( 'WPSC_URL',  plugin_dir_url( __FILE__ ) );
 /* Amorçage                                                                  */
 /* ------------------------------------------------------------------------- */
 require_once WPSC_PATH . '/Core/Init.php';
+require_once WPSC_PATH . '/Core/Uninstall.php';
 
 /**
  * Initialise tous les modules une fois les plugins chargés.
@@ -69,29 +70,6 @@ register_deactivation_hook( __FILE__, 'wpsc_core_deactivate' );
  * Nettoyage complet lors de la désinstallation du plugin.
  */
 function wpsc_core_uninstall(): void {
-    global $wpdb;
-
-    // Options enregistrées par les modules
-    $options = [
-        'wpsc_lr_active',
-        'wpsc_lr_rewrite_flushed',
-        'wpsc_gtm_id',
-        'wpsc_gtm_active',
-    ];
-
-    foreach ( $options as $option ) {
-        delete_option( $option );
-        delete_site_option( $option );
-    }
-
-    // Transient de configuration GTM
-    delete_transient( 'wpsc_gtm_settings' );
-    delete_site_transient( 'wpsc_gtm_settings' );
-
-    // Tous les transients du LoginLimiter
-    if ( $wpdb instanceof \wpdb ) {
-        $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_wpsc_ll_%'" );
-        $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_wpsc_ll_%'" );
-    }
+    \WPSolucesCore\Core\Uninstall::run();
 }
 register_uninstall_hook( __FILE__, 'wpsc_core_uninstall' );


### PR DESCRIPTION
## Summary
- add `Uninstall` class to centralize cleanup tasks
- add wrapper `wpsc_core_uninstall` to call the uninstall class
- call the uninstall class from the main plugin file
- use WordPress APIs to remove `LoginLimiter` transients

## Testing
- `php -l wpsoluces-core/Core/Uninstall.php`
- `php -l wpsoluces-core/wpsoluces-core.php`


------
https://chatgpt.com/codex/tasks/task_e_685e691720ec8323b5f174b54f6ff6cd