### PR TITLE
Improve LoginLimiter transient handling

### DIFF
--- a/wpstarterpack/Core/Uninstall.php
+++ b/wpstarterpack/Core/Uninstall.php
@@ -10,7 +10,6 @@ use WPStarterPack\Modules\LoginRedirect\Model as LoginRedirect;
  */
 class Uninstall {
     public static function run(): void {
-        global $wpdb;
 
         // Autoload plugin classes if the plugin was not fully bootstrapped.
         spl_autoload_register( function ( $class ) {
@@ -47,30 +46,6 @@ class Uninstall {
         delete_site_transient( TagManager::TRANSIENT_KEY );
 
         // Tous les transients du LoginLimiter
-        if ( $wpdb instanceof \wpdb ) {
-            $prefix = 'wpsp_ll_';
-            $like   = $wpdb->esc_like( $prefix );
-            $names  = $wpdb->get_col( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE '_transient_{$like}%' OR option_name LIKE '_transient_timeout_{$like}%'" );
-            foreach ( $names as $name ) {
-                if ( str_starts_with( $name, '_transient_timeout_' ) ) {
-                    delete_option( $name );
-                } elseif ( str_starts_with( $name, '_transient_' ) ) {
-                    $transient = substr( $name, 11 ); // _transient_
-                    delete_transient( $transient );
-                }
-            }
-
-            if ( is_multisite() ) {
-                $site_names = $wpdb->get_col( "SELECT meta_key FROM {$wpdb->sitemeta} WHERE meta_key LIKE '_site_transient_{$like}%' OR meta_key LIKE '_site_transient_timeout_{$like}%'" );
-                foreach ( $site_names as $name ) {
-                    if ( str_starts_with( $name, '_site_transient_timeout_' ) ) {
-                        delete_site_option( $name );
-                    } elseif ( str_starts_with( $name, '_site_transient_' ) ) {
-                        $transient = substr( $name, 16 ); // _site_transient_
-                        delete_site_transient( $transient );
-                    }
-                }
-            }
-        }
+        LoginLimiter::delete_all_transients();
     }
 }

--- a/wpstarterpack/Modules/LoginLimiter/Controller.php
+++ b/wpstarterpack/Modules/LoginLimiter/Controller.php
@@ -23,6 +23,9 @@ class Controller {
             Model::reset( $login );
         } );
 
+        /* Suppression automatique planifiée */
+        add_action( Model::CLEANUP_HOOK, [ Model::class, 'cleanup' ] );
+
         /* Remplace le message WP si c’est notre blocage  */
         add_filter( 'login_errors', [ self::class, 'replace_error' ] );
     }

--- a/wpstarterpack/Modules/LoginLimiter/Model.php
+++ b/wpstarterpack/Modules/LoginLimiter/Model.php
@@ -6,15 +6,79 @@ defined( 'ABSPATH' ) || exit;
 class Model {
 
     /** Nombre maximal d'essais. */
-    private const MAX_ATTEMPTS = 5;
+    public const MAX_ATTEMPTS = 5;
 
     /** Durée de blocage en minutes. */
-    private const LOCK_MINUTES = 30;
+    public const LOCK_MINUTES = 30;
 
-    private const PREFIX = 'wpsp_ll_';
+    /** Préfixe commun à tous les transients du module. */
+    public const TRANSIENT_PREFIX = 'wpsp_ll_';
+
+    /** Nom du hook planifié pour la suppression automatique. */
+    public const CLEANUP_HOOK = 'wpsp_ll_cleanup';
 
     private static function key( string $login ): string {
-        return self::PREFIX . md5( strtolower( $login ) );
+        return self::TRANSIENT_PREFIX . md5( strtolower( $login ) );
+    }
+
+    /**
+     * Planifie la suppression du transient après expiration.
+     */
+    private static function schedule_cleanup( string $key ): void {
+        if ( ! wp_next_scheduled( self::CLEANUP_HOOK, [ $key ] ) ) {
+            wp_schedule_single_event(
+                time() + self::lock_minutes() * MINUTE_IN_SECONDS,
+                self::CLEANUP_HOOK,
+                [ $key ]
+            );
+        }
+    }
+
+    /**
+     * Supprime le transient (appelé via cron).
+     */
+    public static function cleanup( string $key ): void {
+        delete_transient( $key );
+    }
+
+    /**
+     * Supprime tous les transients du LoginLimiter.
+     */
+    public static function delete_all_transients(): void {
+        global $wpdb;
+
+        if ( ! ( $wpdb instanceof \wpdb ) ) {
+            return;
+        }
+
+        $like  = $wpdb->esc_like( self::TRANSIENT_PREFIX );
+        $names = $wpdb->get_col(
+            "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE '_transient_{$like}%' OR option_name LIKE '_transient_timeout_{$like}%'"
+        );
+
+        foreach ( $names as $name ) {
+            if ( str_starts_with( $name, '_transient_timeout_' ) ) {
+                delete_option( $name );
+            } elseif ( str_starts_with( $name, '_transient_' ) ) {
+                $transient = substr( $name, 11 );
+                delete_transient( $transient );
+            }
+        }
+
+        if ( is_multisite() ) {
+            $site_names = $wpdb->get_col(
+                "SELECT meta_key FROM {$wpdb->sitemeta} WHERE meta_key LIKE '_site_transient_{$like}%' OR meta_key LIKE '_site_transient_timeout_{$like}%'"
+            );
+
+            foreach ( $site_names as $name ) {
+                if ( str_starts_with( $name, '_site_transient_timeout_' ) ) {
+                    delete_site_option( $name );
+                } elseif ( str_starts_with( $name, '_site_transient_' ) ) {
+                    $transient = substr( $name, 16 );
+                    delete_site_transient( $transient );
+                }
+            }
+        }
     }
 
     public static function get_attempts( string $login ): int {
@@ -30,11 +94,20 @@ class Model {
     }
 
     public static function increment( string $login ): void {
-        set_transient(
-            self::key( $login ),
-            self::get_attempts( $login ) + 1,
-            self::lock_minutes() * MINUTE_IN_SECONDS
-        );
+        $key      = self::key( $login );
+        $previous = self::get_attempts( $login );
+        $attempts = $previous + 1;
+
+        if ( $previous < self::MAX_ATTEMPTS && $attempts >= self::MAX_ATTEMPTS ) {
+            $expiration = self::lock_minutes() * MINUTE_IN_SECONDS;
+            self::schedule_cleanup( $key );
+        } elseif ( $previous >= self::MAX_ATTEMPTS ) {
+            $expiration = max( 1, self::remaining( $login ) );
+        } else {
+            $expiration = self::lock_minutes() * MINUTE_IN_SECONDS;
+        }
+
+        set_transient( $key, $attempts, $expiration );
     }
 
     public static function reset( string $login ): void {


### PR DESCRIPTION
## Summary
- refactor LoginLimiter constants
- add `delete_all_transients()` helper
- call helper from uninstall routine

## Testing
- `php -l Modules/LoginLimiter/Model.php`
- `php -l Core/Uninstall.php`
- `php -l Modules/LoginLimiter/Controller.php`
- `find . -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_687a5066541883239b872bb77c249d84